### PR TITLE
completed auth/refresh-token

### DIFF
--- a/src/main/java/com/bashverse/backendzifa/auth/api/AuthController.java
+++ b/src/main/java/com/bashverse/backendzifa/auth/api/AuthController.java
@@ -1,10 +1,13 @@
 package com.bashverse.backendzifa.auth.api;
 
 import com.bashverse.backendzifa.auth.domain.LogoutRequest;
+import com.bashverse.backendzifa.auth.domain.RefreshTokenRequest;
 import com.bashverse.backendzifa.auth.infra.keycloak.KeycloakAdminClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @RestController
 @RequestMapping("/auth")
@@ -17,5 +20,11 @@ public class AuthController {
     public ResponseEntity<Void> logout(@RequestBody LogoutRequest request) {
         keycloakAdminClient.logout(request.getRefreshToken());
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/refresh-token")
+    public ResponseEntity<Map<String, Object>> refreshToken(@RequestBody RefreshTokenRequest request) {
+        Map<String, Object> tokens = keycloakAdminClient.refreshToken(request.getRefreshToken());
+        return ResponseEntity.ok(tokens);
     }
 }

--- a/src/main/java/com/bashverse/backendzifa/auth/domain/RefreshTokenRequest.java
+++ b/src/main/java/com/bashverse/backendzifa/auth/domain/RefreshTokenRequest.java
@@ -1,0 +1,8 @@
+package com.bashverse.backendzifa.auth.domain;
+
+import lombok.Data;
+
+@Data
+public class RefreshTokenRequest {
+    private String refreshToken;
+}

--- a/src/main/java/com/bashverse/backendzifa/common/config/SecurityConfig.java
+++ b/src/main/java/com/bashverse/backendzifa/common/config/SecurityConfig.java
@@ -19,7 +19,7 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable()) // Disable CSRF for APIs (adjust if you have non-REST clients)
                 .authorizeHttpRequests(authz -> authz
-                        .requestMatchers("/auth/register","/auth/logout", "/public/**").permitAll() // Allow unauthenticated access where needed
+                        .requestMatchers("/auth/register","/auth/logout","/auth/refresh-token", "/public/**").permitAll() // Allow unauthenticated access where needed
                         .anyRequest().authenticated() // All other requests require authentication
                 )
                 .oauth2ResourceServer(oauth2 ->


### PR DESCRIPTION
Developed auth/refresh-toke endpoint and tested. Getting the output as expected.

To test `POST /auth/refresh-token` endpoint that delegates refresh token to Keycloak, follow these steps:
1. Obtain initial access and refresh tokens from Keycloak
Request tokens using password grant (replace placeholders):

`curl -X POST "http://localhost:8081/realms/{realm}/protocol/openid-connect/token" \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d "client_id={client-id}" \
  -d "client_secret={client-secret}" \
  -d "grant_type=password" \
  -d "username={username}" \
  -d "password={password}"
`
Save the `refresh_token` from this response.

2. Call your backend `/auth/refresh-token` API with the refresh token
curl -X POST "http://localhost:8080/auth/refresh-token" \
  -H "Content-Type: application/json" \
  -d '{"refreshToken":"{refresh_token_here}"}'

3. Verify the response
	•	You should receive a JSON response with a new `access_token` and usually a new `refresh_token`.
	•	The tokens should be valid and usable for requests requiring authorization.

4. Test with invalid or expired refresh token
	•	Send an incorrect or expired refresh token in the request.
	•	Your API should respond with an error indicating token refresh failure.